### PR TITLE
make worldmap compatible to older php again

### DIFF
--- a/share/server/core/sources/worldmap.php
+++ b/share/server/core/sources/worldmap.php
@@ -173,7 +173,7 @@ function line_parameters($ax, $ay, $bx, $by) {
 
     if ($s == -0) $s = 0;
 
-    return [$r, $s, $t];
+    return array($r $s $t);
 }
 function worldmap_get_objects_by_bounds($sw_lng, $sw_lat, $ne_lng, $ne_lat) {
     global $DB;


### PR DESCRIPTION
simple arrays ( ["foo", "bar"] ) are introduced in php 5.4. With this change the worldmap works again with php older than 5.4